### PR TITLE
Update 02 - tf.layers.py

### DIFF
--- a/07 - CNN/02 - tf.layers.py
+++ b/07 - CNN/02 - tf.layers.py
@@ -18,11 +18,11 @@ is_training = tf.placeholder(tf.bool)
 # 활성화 함수 적용은 물론, 컨볼루션 신경망을 만들기 위한 나머지 수치들은 알아서 계산해줍니다.
 # 특히 Weights 를 계산하는데 xavier_initializer 를 쓰고 있는 등,
 # 크게 신경쓰지 않아도 일반적으로 효율적인 신경망을 만들어줍니다.
-L1 = tf.layers.conv2d(X, 32, [3, 3])
+L1 = tf.layers.conv2d(X, 32, [3, 3], activation=tf.nn.relu)
 L1 = tf.layers.max_pooling2d(L1, [2, 2], [2, 2])
 L1 = tf.layers.dropout(L1, 0.7, is_training)
 
-L2 = tf.layers.conv2d(L1, 64, [3, 3])
+L2 = tf.layers.conv2d(L1, 64, [3, 3], activation=tf.nn.relu)
 L2 = tf.layers.max_pooling2d(L2, [2, 2], [2, 2])
 L2 = tf.layers.dropout(L2, 0.7, is_training)
 


### PR DESCRIPTION
책의 131페이지를 읽던 도중,

```
W1 = tf.Variable(tf.random_normal([3, 3, 1, 32], stddev=0.01))
L1 = tf.nn.conv2d(X, W1, strides=[1, 1, 1, 1], padding='SAME')
L1 = tf.nn.relu(L1)
L1 = tf.nn.max_pool(L1, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='SAME')
```

코드를 아래와 같이 수정하는 부분에서, relu activation 함수를 설정하는 것이 누락된 것 같습니다.

```
L1 = tf.layers.conv2d(X, 32, [3, 3])
L1 = tf.layers.max_pooling2d(L1, [2, 2], [2, 2])
```

혹시나 따로 activation 함수를 지정하지 않으면 자동으로 ReLU 함수로 설정되는 것인지
[https://github.com/tensorflow/tensorflow/blob/r1.4/tensorflow/python/layers/convolutional.py](https://github.com/tensorflow/tensorflow/blob/r1.4/tensorflow/python/layers/convolutional.py)

코드를 참고해봤지만, 그런 부분이 없어서 Pull Request 합니다.
  